### PR TITLE
FEAT: 좋아요 페이지에 좋아요한 영상이 보이도록 구현 & 탈퇴 버튼 클릭시 로그인 되어있는 유저만 삭제되도록 변경

### DIFF
--- a/BabTube/BabTube/LikeViewController/LikeViewController.swift
+++ b/BabTube/BabTube/LikeViewController/LikeViewController.swift
@@ -19,7 +19,7 @@ class LikeViewController: UIViewController, UITableViewDataSource, UITableViewDe
     //API 변수
     private let apiHandler: APIHandler = APIHandler()
     private let imageLoader: ImageLoader = ImageLoader()
-    private var likeVideoList = UserDataManager.shared.loginUser?.likeVideo
+    private var likeVideoList = UserDataManager.shared.getLikeVideos()
     
     // 테이블 뷰 생성
     private let likeViewTable: UITableView = {
@@ -82,7 +82,7 @@ class LikeViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     // 셀의 갯수
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if likeVideoList?.count == 0 {
+        if likeVideoList.count == 0 {
             likeViewTable.isHidden = true
             nonLikeVideoLabel.isHidden = false
         }
@@ -90,15 +90,14 @@ class LikeViewController: UIViewController, UITableViewDataSource, UITableViewDe
             likeViewTable.isHidden = false
             nonLikeVideoLabel.isHidden = true
         }
-        return likeVideoList?.count ?? 0
+        return likeVideoList.count
     }
 
     // 셀에 표시될 내용
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "detailCellIdentifier", for: indexPath) as! DetailLikeTableViewCell
         
-        guard let likeVideoList,
-                let snippet = likeVideoList[indexPath.row].snippet else {
+        guard let snippet = likeVideoList[indexPath.row].snippet else {
             return cell
         }
         cell.likeUpdateUI(snippet: snippet, items: likeVideoList)
@@ -110,7 +109,7 @@ class LikeViewController: UIViewController, UITableViewDataSource, UITableViewDe
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
          
         //VideoDetail 화면으로 이동 및 VideoID 넘겨주기
-        if let likeVideoList = likeVideoList, indexPath.row < likeVideoList.count {
+        if indexPath.row < likeVideoList.count {
             let videoId = likeVideoList[indexPath.row].videoId
             let videoDetail = VideoDetailViewController(videoId: videoId)
             navigationController?.pushViewController(videoDetail, animated: true)

--- a/BabTube/BabTube/Model/UserData.swift
+++ b/BabTube/BabTube/Model/UserData.swift
@@ -8,12 +8,14 @@
 import UIKit
 
 struct UserData: Codable {
+    typealias VideoID = String
+    typealias ThumbnailURL = String
     var name: String?
     var userID: String
     var password: String
     var nickname: String?
     var userImage: Data?
-    var likeVideo: [LikeVideo] = []
+    var likeVideo: [VideoID:ThumbnailURL] = [:]
     var viewHistory: [ViewHistory] = []
 }
 

--- a/BabTube/BabTube/Model/UserData.swift
+++ b/BabTube/BabTube/Model/UserData.swift
@@ -15,11 +15,12 @@ struct UserData: Codable {
     var password: String
     var nickname: String?
     var userImage: Data?
-    var likeVideo: [VideoID:ThumbnailURL] = [:]
+    var likeVideo: [VideoID:LikeVideo] = [:]
     var viewHistory: [ViewHistory] = []
 }
 
 struct LikeVideo: Codable {
+    var likeTime: Date = Date()
     var videoId: String
     var snippet: Snippet?
     var videoThumbnail: String

--- a/BabTube/BabTube/Model/UserDataManager.swift
+++ b/BabTube/BabTube/Model/UserDataManager.swift
@@ -77,11 +77,9 @@ class UserDataManager {
     func addLikeVideo(userID: String, likeVideo: LikeVideo) {
         guard let userIndex = users.firstIndex(where: { $0.userID == userID }),
             var likeAddedLoginUser = loginUser else { return }
-//        likeAddedLoginUser.likeVideo.insert(likeVideo, at: 0)
-        likeAddedLoginUser.likeVideo[likeVideo.videoId] = likeVideo.videoThumbnail
+        likeAddedLoginUser.likeVideo[likeVideo.videoId] = likeVideo
         loginUser = likeAddedLoginUser
-        users[userIndex].likeVideo[likeVideo.videoId] = likeVideo.videoThumbnail
-//        users[userIndex].likeVideo.insert(likeVideo, at: 0)
+        users[userIndex].likeVideo[likeVideo.videoId] = likeVideo
         saveUsers()
     }
 
@@ -97,12 +95,9 @@ class UserDataManager {
     }
 
     // 좋아하는 동영상 목록 반환
-    func getLikeVideos(userIndex: Int) -> [String:String] {
-        guard userIndex >= 0, userIndex < users.count else {
-            return [:]
-        }
-
-        return users[userIndex].likeVideo
+    func getLikeVideos() -> [LikeVideo] {
+        guard let loginUser else { return [] }
+        return loginUser.likeVideo.values.sorted(by: { $0.likeTime < $1.likeTime })
     }
     
     func addViewHistory(userID: String,viewHistory: ViewHistory){

--- a/BabTube/BabTube/Model/UserDataManager.swift
+++ b/BabTube/BabTube/Model/UserDataManager.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class UserDataManager {
+    typealias VideoID = String
+    typealias ThumnalURL = String
     static let shared = UserDataManager() // Singleton 인스턴스
 
     private let userDefaults = UserDefaults.standard
@@ -72,46 +74,48 @@ class UserDataManager {
     }
 
     // 좋아요 표시한 동영상 저장하기
-    func addLikeVideo(userIndex: Int, likeVideo: LikeVideo) {
-        guard userIndex >= 0, userIndex < users.count else {
-            return // 유효하지 않은 인덱스일 경우 처리하지 않음
-        }
-
-        users[userIndex].likeVideo.append(likeVideo)
+    func addLikeVideo(userID: String, likeVideo: LikeVideo) {
+        guard let userIndex = users.firstIndex(where: { $0.userID == userID }),
+            var likeAddedLoginUser = loginUser else { return }
+//        likeAddedLoginUser.likeVideo.insert(likeVideo, at: 0)
+        likeAddedLoginUser.likeVideo[likeVideo.videoId] = likeVideo.videoThumbnail
+        loginUser = likeAddedLoginUser
+        users[userIndex].likeVideo[likeVideo.videoId] = likeVideo.videoThumbnail
+//        users[userIndex].likeVideo.insert(likeVideo, at: 0)
         saveUsers()
     }
 
     // 좋아요 표시한 동영상 제거
-    func removeLikeVideo(userIndex: Int, likeVideoIndex: Int) {
-        guard userIndex >= 0, userIndex < users.count else {
-            return // 유효하지 않은 사용자 인덱스
-        }
-
-        var user = users[userIndex]
-
-        guard likeVideoIndex >= 0, likeVideoIndex < user.likeVideo.count else {
-            return
-        }
-        user.likeVideo.remove(at: likeVideoIndex)
+    func removeLikeVideo(userID: String, likeVideoID: String) {
+        guard let userIndex = users.firstIndex(where: { $0.userID == userID }),
+            var likeAddedLoginUser = loginUser else { return }
+        likeAddedLoginUser.likeVideo[likeVideoID] = nil
+        
+        loginUser = likeAddedLoginUser
+        users[userIndex].likeVideo[likeVideoID] = nil
         saveUsers()
     }
 
     // 좋아하는 동영상 목록 반환
-    func getLikeVideos(userIndex: Int) -> [LikeVideo] {
+    func getLikeVideos(userIndex: Int) -> [String:String] {
         guard userIndex >= 0, userIndex < users.count else {
-            return []
+            return [:]
         }
 
         return users[userIndex].likeVideo
     }
     
-    func addViewHistory(userIndex: Int,viewHistory: ViewHistory){
-        guard userIndex >= 0, userIndex < users.count else {
-            return // 유효하지 않은 인덱스일 경우 처리하지 않음
-        }
-        users[userIndex].viewHistory.append(viewHistory)
+    func addViewHistory(userID: String,viewHistory: ViewHistory){
+        guard let userIndex = users.firstIndex(where: { $0.userID == userID }),
+            var viewHistoryAddedLoginUser = loginUser else { return }
+        viewHistoryAddedLoginUser.viewHistory.removeAll(where: { $0.videoId == viewHistory.videoId })
+        if viewHistoryAddedLoginUser.viewHistory.count == 10 { viewHistoryAddedLoginUser.viewHistory.removeLast() }
+        viewHistoryAddedLoginUser.viewHistory.insert(viewHistory, at: 0)
+        loginUser = viewHistoryAddedLoginUser
+        users[userIndex].viewHistory.insert(viewHistory, at: 0)
         saveUsers()
     }
+    
     func removeViewHistory(userIndex: Int, viewHistoryIndex: Int){
         guard userIndex >= 0, userIndex < users.count else {
             return // 유효하지 않은 인덱스일 경우 처리하지 않음
@@ -124,7 +128,7 @@ class UserDataManager {
         saveUsers()
     }
     // 사용자 데이터 초기화
-    func clearUsers() {
+    func removeUser(userID: String) {
         users.removeAll()
         userDefaults.removeObject(forKey: "users")
     }

--- a/BabTube/BabTube/MyPageViewController/MyPageViewController.swift
+++ b/BabTube/BabTube/MyPageViewController/MyPageViewController.swift
@@ -23,6 +23,8 @@ class MyPageViewController: UIViewController {
         
         // 스크롤 없애기
         tableView.isScrollEnabled = false
+        
+        tableView.showsHorizontalScrollIndicator = false
         return tableView
     }()
     
@@ -176,11 +178,9 @@ extension MyPageViewController: UITableViewDelegate, UITableViewDataSource {
             dismiss(animated: true)
         }
         else if indexPath.row == 3 {
-            UserDataManager.shared.clearUsers()
-            let loginVC = LoginViewController()
-            loginVC.modalPresentationStyle = .fullScreen
-            loginVC.modalTransitionStyle = .coverVertical
-            present(loginVC, animated: true)
+            guard let loginUser = UserDataManager.shared.loginUser else { return }
+            UserDataManager.shared.removeUser(userID: loginUser.userID)
+            dismiss(animated: true)
         }
     }
 }

--- a/BabTube/BabTube/VideoDetailViewController/VideoDetailViewController.swift
+++ b/BabTube/BabTube/VideoDetailViewController/VideoDetailViewController.swift
@@ -140,6 +140,7 @@ final class VideoDetailViewController: UIViewController {
             return
         }
         videoDecriptionStackView.updateArrangedSubviews(title: snippet.title, description: snippet.description, publishTime: snippet.publishedAt, statistics: statistics)
+        addViewHistory(thumbnails: snippet.thumbnails)
         DispatchQueue.main.async {
             self.view.setNeedsLayout()
         }
@@ -159,6 +160,12 @@ final class VideoDetailViewController: UIViewController {
         alertVC.addAction(removeAction)
         
         present(alertVC, animated: true)
+    }
+    
+    private func addViewHistory(thumbnails: Thumbanils) {
+        guard let loginUser = UserDataManager.shared.loginUser else { return }
+        let viewHistory = ViewHistory(videoId: videoId, videoThumbnail: thumbnails.high.url)
+        UserDataManager.shared.addViewHistory(userId: loginUser.userID, viewHistory: viewHistory)
     }
     
 }
@@ -187,6 +194,13 @@ extension VideoDetailViewController {
                 self.view.setNeedsLayout()
                 self.scrollToBottom()
             }
+        }
+        
+        guard let loginUserID = UserDataManager.shared.loginUser?.userID,
+              let snippet else { return }
+        videoDecriptionStackView.likeVideoAddHandelr = { [weak self] likeSelected in
+            guard let self else { return }
+            UserDataManager.shared.addLikeVideo(userID: loginUserID, likeVideo: LikeVideo(videoId: self.videoId, videoThumbnail: snippet.thumbnails.default.url))
         }
         
         guard let userData = UserDataManager.shared.loginUser,

--- a/BabTube/BabTube/VideoDetailViewController/VideoDetailViewController.swift
+++ b/BabTube/BabTube/VideoDetailViewController/VideoDetailViewController.swift
@@ -165,7 +165,7 @@ final class VideoDetailViewController: UIViewController {
     private func addViewHistory(thumbnails: Thumbanils) {
         guard let loginUser = UserDataManager.shared.loginUser else { return }
         let viewHistory = ViewHistory(videoId: videoId, videoThumbnail: thumbnails.high.url)
-        UserDataManager.shared.addViewHistory(userId: loginUser.userID, viewHistory: viewHistory)
+        UserDataManager.shared.addViewHistory(userID: loginUser.userID, viewHistory: viewHistory)
     }
     
 }
@@ -200,7 +200,11 @@ extension VideoDetailViewController {
               let snippet else { return }
         videoDecriptionStackView.likeVideoAddHandelr = { [weak self] likeSelected in
             guard let self else { return }
-            UserDataManager.shared.addLikeVideo(userID: loginUserID, likeVideo: LikeVideo(videoId: self.videoId, videoThumbnail: snippet.thumbnails.default.url))
+            if likeSelected {
+                UserDataManager.shared.addLikeVideo(userID: loginUserID, likeVideo: LikeVideo(videoId: self.videoId, videoThumbnail: snippet.thumbnails.default.url))
+            } else {
+                UserDataManager.shared.removeLikeVideo(userID: loginUserID, likeVideoID: self.videoId)
+            }
         }
         
         guard let userData = UserDataManager.shared.loginUser,

--- a/BabTube/BabTube/VideoDetailViewController/View/VideoDescriptionVerticalStackView.swift
+++ b/BabTube/BabTube/VideoDetailViewController/View/VideoDescriptionVerticalStackView.swift
@@ -34,7 +34,7 @@ class VideoDescriptionVerticalStackView: UIStackView {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.distribution = .fillEqually
+        stackView.distribution = .fill
         stackView.spacing = 6
         return stackView
     }()
@@ -65,6 +65,7 @@ class VideoDescriptionVerticalStackView: UIStackView {
         return label
     }()
     private var isMoreDescriptionHidden: Bool = true
+    var likeVideoAddHandelr: ((Bool)->Void)?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -110,6 +111,7 @@ extension VideoDescriptionVerticalStackView {
     
     @objc private func likeButtonClick() {
         likeButton.isSelected.toggle()
+        likeVideoAddHandelr?(likeButton.isSelected)
     }
     
     @objc private func moreDescription() {


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
좋아요 페이지에 좋아요한 영상이 보이도록 구현 & 탈퇴 버튼 클릭시 로그인 되어있는 유저만 삭제되도록 변경
또한 UserData에 LikeVideo를 array -> dictionary 로 변경 : 변경하게 된 이유는 좋아요 영상이 많아지게 될경우 느려질 상황을 대비해서 변경함
## 작업내용 (이미지)
api를 전부 사용하여 이미지를 첨부할 수 없음...