### PR TITLE
Bug: 회원가입페이지에서 이름 한글로 입력시 한글조합이 안되는 버그

### DIFF
--- a/BabTube/BabTube/LoginViewController/MembershipViewController.swift
+++ b/BabTube/BabTube/LoginViewController/MembershipViewController.swift
@@ -114,7 +114,6 @@ class MembershipViewController: UIViewController {
         
         signUp.backgroundColor = .systemGray5
         
-        nameTextField.delegate = self
         emailAdressTextField.delegate = self
         passwordTextField.delegate = self
         passwordCheckTextField.delegate = self
@@ -213,17 +212,15 @@ class MembershipViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         makeUi()
     }
-    
 }
 
 extension MembershipViewController: UITextFieldDelegate {
     func textFieldDidChange(_ textField: UITextField) {
-        let isNameEmpty = nameTextField.text?.isEmpty ?? true
         let isEmailEmpty = emailAdressTextField.text?.isEmpty ?? true
         let isPasswordEmpty = passwordTextField.text?.isEmpty ?? true
         let isPasswordCheckEmpty = passwordCheckTextField.text?.isEmpty ?? true
         
-        if !isNameEmpty && !isEmailEmpty && !isPasswordEmpty && !isPasswordCheckEmpty {
+        if !isEmailEmpty && !isPasswordEmpty && !isPasswordCheckEmpty {
             signUp.backgroundColor = .mainColor
         } else {
             signUp.backgroundColor = .systemGray5
@@ -239,7 +236,6 @@ extension MembershipViewController: UITextFieldDelegate {
         return false
     }
 }
-
 
 extension MembershipViewController {
     func makeUi() {


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
회원가입페이지에서 이름 한글로 입력시 한글조합이 안되는 버그
## 작업내용 (이미지)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-09-11 at 10 28 42](https://github.com/BabTubeProject/BabTube/assets/125369115/a19ace60-0d81-48a8-b77e-6af184a85a61)
